### PR TITLE
Add support of system roles management

### DIFF
--- a/include/role/parser.h
+++ b/include/role/parser.h
@@ -36,9 +36,9 @@ int librole_realloc_groups(long int **, gid_t ***, long int);
 
 int librole_reading(const char *, struct librole_graph *);
 
-int librole_writing(const char *, struct librole_graph *, int numeric_flag);
-int librole_write(const char* pam_role, struct librole_graph *G);
-int librole_write_dir(const char* filename, const char* pam_role, struct librole_graph *G);
+int librole_writing(const char *, struct librole_graph *, int numeric_flag, int empty_flag);
+int librole_write(const char* pam_role, struct librole_graph *G, int empty_flag);
+int librole_write_dir(const char* filename, const char* pam_role, struct librole_graph *G, int empty_flag);
 
 int librole_dfs(struct librole_graph *, gid_t, librole_group_collector *);
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -409,7 +409,7 @@ static int write_group(FILE *f, int gid, int delim, int numeric_flag)
 
 /* TODO: the same like in rolelst
  TODO: write in a new file and atomically rename */
-int librole_writing(const char *file, struct librole_graph *G, int numeric_flag)
+int librole_writing(const char *file, struct librole_graph *G, int numeric_flag, int empty_flag)
 {
     int i, j, result;
     FILE *f = fopen(file, "w");
@@ -417,7 +417,7 @@ int librole_writing(const char *file, struct librole_graph *G, int numeric_flag)
         return LIBROLE_IO_ERROR;
 
     for(i = 0; i < G->size; i++) {
-        if (!G->gr[i].size)
+        if (!G->gr[i].size && !empty_flag)
             continue;
 
         result = write_group(f, G->gr[i].gid, -1, numeric_flag);
@@ -440,7 +440,7 @@ libnss_role_writing_exit:
     return result;
 }
 
-int librole_write(const char* pam_role, struct librole_graph *G)
+int librole_write(const char* pam_role, struct librole_graph *G, int empty_flag)
 {
     int result;
     int pam_status;
@@ -456,7 +456,7 @@ int librole_write(const char* pam_role, struct librole_graph *G)
         goto exit;
     }
 
-    result = librole_writing(LIBROLE_CONFIG, G, 0);
+    result = librole_writing(LIBROLE_CONFIG, G, 0, empty_flag);
 
     librole_unlock(LIBROLE_CONFIG);
 
@@ -466,7 +466,7 @@ exit:
     return result;
 }
 
-int librole_write_dir(const char* filename, const char* pam_role, struct librole_graph *G)
+int librole_write_dir(const char* filename, const char* pam_role, struct librole_graph *G, int empty_flag)
 {
     int result = 0;
     int pam_status;
@@ -498,7 +498,7 @@ int librole_write_dir(const char* filename, const char* pam_role, struct librole
         goto librole_write_dir_done;
     }
 
-    result = librole_writing(fullpath, G, 0);
+    result = librole_writing(fullpath, G, 0, empty_flag);
 
     librole_unlock(fullpath);
 

--- a/src/roleadd.c
+++ b/src/roleadd.c
@@ -52,7 +52,7 @@ static void print_help(void)
     fprintf(stdout,
         "\t-f [ --file=file.role ]\tchange role in additional file /etc/role.d/file.role\n");
     fprintf(stdout,
-        "\t-S [ --system ]\tchange system ROLE in additional file /etc/role.d/ROLE.role");
+        "\t-S [ --system ]\t\tchange system ROLE in additional file /etc/role.d/ROLE.role");
     fprintf(stdout, "\n");
 }
 

--- a/src/roleadd.c
+++ b/src/roleadd.c
@@ -20,6 +20,7 @@
  * USA.
  */
 #include <stdio.h>
+#include <string.h>
 #include <stdlib.h>
 #include <getopt.h>
 #include <unistd.h>
@@ -33,7 +34,8 @@ struct option rolelst_opt[] = {
     {"set", no_argument, 0, 's'},
     {"skip-missing-groups", no_argument, 0, 'm'},
     {"version", no_argument, 0, 'v'},
-    {"file", no_argument, 0, 'f'}
+    {"system", no_argument, 0, 'S'},
+    {"file", required_argument, 0, 'f'}
 };
 
 static void print_help(void)
@@ -48,17 +50,20 @@ static void print_help(void)
     fprintf(stdout,
         "\t-v [ --version]\t\tprint roleadd version being used\n");
     fprintf(stdout,
-        "\t-f [ --file ]\tadd role to file in /etc/role.d/\n");
+        "\t-f [ --file=file.role ]\tchange role in additional file /etc/role.d/file.role\n");
+    fprintf(stdout,
+        "\t-S [ --system ]\tchange system ROLE in additional file /etc/role.d/ROLE.role");
     fprintf(stdout, "\n");
 }
 
-static int parse_options(int argc, char **argv, int *set_flag, int *skip_flag, int *roled_flag)
+static int parse_options(int argc, char **argv, int *set_flag, int *skip_flag, int *roled_flag, char **roled_file, int *system_role_flag)
 {
     int c, opt_ind;
     *set_flag = 0;
     *skip_flag = 0;
     *roled_flag = 0;
-    while((c = getopt_long(argc, argv, "hmsvf", rolelst_opt, &opt_ind)) != -1) {
+    *system_role_flag = 0;
+    while((c = getopt_long(argc, argv, "hmsvf:S", rolelst_opt, &opt_ind)) != -1) {
         switch(c) {
             case 'h':
                 print_help();
@@ -71,6 +76,10 @@ static int parse_options(int argc, char **argv, int *set_flag, int *skip_flag, i
                 break;
             case 'f':
                 *roled_flag = 1;
+                *roled_file = strdup(optarg);
+                break;
+            case 'S':
+                *system_role_flag = 1;
                 break;
             case 'v':
                 printf("roleadd is the utility for libnss_role version %s\n",
@@ -87,14 +96,19 @@ static int parse_options(int argc, char **argv, int *set_flag, int *skip_flag, i
 
 int main(int argc, char **argv) {
     struct librole_graph G;
-    int result, i, set_flag, skip_flag, roled_flag;
+    int result, set_flag, skip_flag, roled_flag, system_role_flag;
     struct librole_ver new_role;
-    const char *filename = NULL;
+    char *filename = NULL;
 
-    if (!parse_options(argc, argv, &set_flag, &skip_flag, &roled_flag))
+    if (!parse_options(argc, argv, &set_flag, &skip_flag, &roled_flag, &filename, &system_role_flag))
         return 0;
 
     if (optind >= argc) {
+        print_help();
+        return 1;
+    }
+
+    if (roled_flag && system_role_flag) {
         print_help();
         return 1;
     }
@@ -104,7 +118,20 @@ int main(int argc, char **argv) {
         goto exit;
 
     if (roled_flag) {
-        filename = argv[optind++];
+        result = librole_validate_filename_from_dir(filename);
+        if (result != LIBROLE_OK)
+            goto exit;
+
+        librole_read_file_from_dir(LIBROLE_CONFIG_DIR, filename, &G);
+    } else if (system_role_flag) {
+        int filename_sz = strlen(argv[optind]) + strlen(LIBROLE_ROLE_EXTENSION) + 1;
+
+        filename = malloc(filename_sz);
+        if (filename == NULL)
+            goto exit;
+
+        strncpy(filename, argv[optind], filename_sz);
+        strncat(filename, LIBROLE_ROLE_EXTENSION, strlen(LIBROLE_ROLE_EXTENSION));
 
         result = librole_validate_filename_from_dir(filename);
         if (result != LIBROLE_OK)
@@ -126,12 +153,14 @@ int main(int argc, char **argv) {
     else
         result = librole_role_add(&G, new_role);
 
-    if (result == LIBROLE_OK && roled_flag)
-        result = librole_write_dir(filename, "roleadd", &G);
+    if (result == LIBROLE_OK && (roled_flag || system_role_flag))
+        result = librole_write_dir(filename, "roleadd", &G, 1);
     else if (result == LIBROLE_OK)
-        result = librole_write("roleadd", &G);
+        result = librole_write("roleadd", &G, 1);
 
 exit:
+    if (filename != NULL)
+        free(filename);
     librole_print_error(result);
     librole_graph_free(&G);
     return result;

--- a/src/roledel.c
+++ b/src/roledel.c
@@ -20,6 +20,7 @@
  * USA.
  */
 #include <stdio.h>
+#include <string.h>
 #include <stdlib.h>
 #include <getopt.h>
 #include <unistd.h>
@@ -32,7 +33,8 @@ struct option rolelst_opt[] = {
     {"remove", no_argument, 0, 'r'},
     {"skip-missing-groups", no_argument, 0, 'm'},
     {"version", no_argument, 0, 'v'},
-    {"file", no_argument, 0, 'f'}
+    {"system", no_argument, 0, 'S'},
+    {"file", required_argument, 0, 'f'}
 };
 
 static void print_help(void)
@@ -47,17 +49,20 @@ static void print_help(void)
     fprintf(stdout,
         "\t-v [ --version]\t\tprint roledel version being used\n");
     fprintf(stdout,
-        "\t-f [ --file ]\tremove role from file in /etc/role.d/\n");
+        "\t-f [ --file=file.role ]\tchange role in additional file /etc/role.d/file.role\n");
+    fprintf(stdout,
+        "\t-S [ --system ]\tchange system ROLE in additional file /etc/role.d/ROLE.role");
     fprintf(stdout, "\n");
 }
 
-static int parse_options(int argc, char **argv, int *remove_flag, int *skip_flag, int *roled_flag)
+static int parse_options(int argc, char **argv, int *remove_flag, int *skip_flag, int *roled_flag, char **roled_file, int *system_role_flag)
 {
     int c, opt_ind;
     *remove_flag = 0;
     *skip_flag = 0;
     *roled_flag = 0;
-    while((c = getopt_long(argc, argv, "hmrvf", rolelst_opt, &opt_ind)) != -1) {
+    *system_role_flag = 0;
+    while((c = getopt_long(argc, argv, "hmsvf:S", rolelst_opt, &opt_ind)) != -1) {
         switch(c) {
             case 'h':
                 print_help();
@@ -70,6 +75,10 @@ static int parse_options(int argc, char **argv, int *remove_flag, int *skip_flag
                 break;
             case 'f':
                 *roled_flag = 1;
+                *roled_file = strdup(optarg);
+                break;
+            case 'S':
+                *system_role_flag = 1;
                 break;
             case 'v':
                 printf("roledel is the utility for libnss_role version %s\n",
@@ -86,14 +95,19 @@ static int parse_options(int argc, char **argv, int *remove_flag, int *skip_flag
 
 int main(int argc, char **argv) {
     struct librole_graph G;
-    int result, i, remove_flag, skip_flag, roled_flag;
+    int result, remove_flag, skip_flag, roled_flag, system_role_flag;
     struct librole_ver del_role;
-    const char *filename = NULL;
+    char *filename = NULL;
 
-    if (!parse_options(argc, argv, &remove_flag, &skip_flag, &roled_flag))
+    if (!parse_options(argc, argv, &remove_flag, &skip_flag, &roled_flag, &filename, &system_role_flag))
         return 0;
 
     if (optind >= argc) {
+        print_help();
+        return 1;
+    }
+
+    if (roled_flag && system_role_flag) {
         print_help();
         return 1;
     }
@@ -103,7 +117,20 @@ int main(int argc, char **argv) {
         goto exit;
 
     if (roled_flag) {
-        filename = argv[optind++];
+        result = librole_validate_filename_from_dir(filename);
+        if (result != LIBROLE_OK)
+            goto exit;
+
+        librole_read_file_from_dir(LIBROLE_CONFIG_DIR, filename, &G);
+    } else if (system_role_flag) {
+        int filename_sz = strlen(argv[optind]) + strlen(LIBROLE_ROLE_EXTENSION) + 1;
+
+        filename = malloc(filename_sz);
+        if (filename == NULL)
+            goto exit;
+
+        strncpy(filename, argv[optind], filename_sz);
+        strncat(filename, LIBROLE_ROLE_EXTENSION, strlen(LIBROLE_ROLE_EXTENSION));
 
         result = librole_validate_filename_from_dir(filename);
         if (result != LIBROLE_OK)
@@ -125,12 +152,19 @@ int main(int argc, char **argv) {
     else
         result = librole_role_del(&G, del_role);
 
-    if (result == LIBROLE_OK && roled_flag)
-        result = librole_write_dir(filename, "roledel", &G);
-    else if (result == LIBROLE_OK)
-        result = librole_write("roledel", &G);
+    if (result == LIBROLE_OK) {
+        if (roled_flag) {
+            result = librole_write_dir(filename, "roledel", &G, 0);
+        } else if (system_role_flag) {
+            result = librole_write_dir(filename, "roledel", &G, 1);
+        } else {
+            result = librole_write("roledel", &G, 0);
+        }
+    }
 
 exit:
+    if (filename != NULL)
+        free(filename);
     librole_print_error(result);
     librole_graph_free(&G);
     return result;

--- a/src/roledel.c
+++ b/src/roledel.c
@@ -51,7 +51,7 @@ static void print_help(void)
     fprintf(stdout,
         "\t-f [ --file=file.role ]\tchange role in additional file /etc/role.d/file.role\n");
     fprintf(stdout,
-        "\t-S [ --system ]\tchange system ROLE in additional file /etc/role.d/ROLE.role");
+        "\t-S [ --system ]\t\tchange system ROLE in additional file /etc/role.d/ROLE.role");
     fprintf(stdout, "\n");
 }
 

--- a/src/rolelst.c
+++ b/src/rolelst.c
@@ -21,6 +21,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <getopt.h>
 #include <unistd.h>
 #include <errno.h>
@@ -34,18 +35,22 @@ struct option rolelst_opt[] = {
     {"help", no_argument, 0, 'h'},
     {"numeric", no_argument, 0, 'n'},
     {"version", no_argument, 0, 'v'},
-    {"verbose", no_argument, 0, 'V'}
+    {"verbose", no_argument, 0, 'V'},
+    {"system", required_argument, 0, 'S'},
+    {"file", required_argument, 0, 'f'}
 };
 
 struct rolelst_settings {
     int numeric_flag;
     int verbose_mode;
+    const char* roled_filename;
+    const char* system_role;
 };
 
 static int parse_options(int argc, char **argv, struct rolelst_settings *settings)
 {
     int c, opt_ind;
-    while((c = getopt_long(argc, argv, "hnvV", rolelst_opt, &opt_ind)) != -1) {
+    while((c = getopt_long(argc, argv, "hnvVf:S:", rolelst_opt, &opt_ind)) != -1) {
         switch(c) {
             case 'h':
                 fprintf(stdout, "Usage: rolelst [-hnv]\n");
@@ -56,7 +61,11 @@ static int parse_options(int argc, char **argv, struct rolelst_settings *setting
                 fprintf(stdout,
                     "\t-v [ --version]\t\tprint roledel version being used\n");
                 fprintf(stdout,
-                    "\t-V [ --verbose]\t\tprint extra information about role sources");
+                    "\t-V [ --verbose]\t\tprint extra information about role sources\n");
+                fprintf(stdout,
+                    "\t-f [ --file=file.role ]\tshow role in additional file /etc/role.d/file.role\n");
+                fprintf(stdout,
+                    "\t-S [ --system=ROLE ]\tshow system ROLE in additional file /etc/role.d/ROLE.role");
                 fprintf(stdout, "\n");
                 fflush(stdout);
                 return 0;
@@ -65,6 +74,12 @@ static int parse_options(int argc, char **argv, struct rolelst_settings *setting
                 break;
             case 'V':
                 settings->verbose_mode = 1;
+                break;
+            case 'f':
+                settings->roled_filename = optarg;
+                break;
+            case 'S':
+                settings->system_role = optarg;
                 break;
             case 'v':
                 printf("rolelst is the utility for libnss_role version %s\n",
@@ -84,25 +99,69 @@ int main(int argc, char **argv) {
     struct rolelst_settings settings;
     struct librole_graph G;
     int result = LIBROLE_OK;
+    char* filename = NULL;
     memset(&settings, 0, sizeof(settings));
 
     if (!parse_options(argc, argv, &settings))
         return 0;
+//    printf("# system opt = %s, roled = %s\n", settings.roled_filename, settings.system_role);
 
     result = librole_graph_init(&G);
     if (result != LIBROLE_OK)
         goto exit;
 
-    result = librole_reading(LIBROLE_CONFIG, &G);
-    if (result != LIBROLE_OK)
-        goto exit;
-    if (0 != settings.verbose_mode) {
-        printf("# Settings read from /etc/role:\n");
+    if (settings.roled_filename) {
+        filename = strdup(settings.roled_filename);
+        if (filename == NULL)
+            goto exit;
+
+        result = librole_validate_filename_from_dir(filename);
+        if (result != LIBROLE_OK)
+            goto exit;
+
+        librole_read_file_from_dir(LIBROLE_CONFIG_DIR, filename, &G);
+    } else if (settings.system_role) {
+        int filename_sz = strlen(settings.system_role) + strlen(LIBROLE_ROLE_EXTENSION) + 1;
+
+        filename = malloc(filename_sz);
+        if (filename == NULL)
+            goto exit;
+
+        strncpy(filename, settings.system_role, filename_sz);
+        strncat(filename, LIBROLE_ROLE_EXTENSION, strlen(LIBROLE_ROLE_EXTENSION));
+
+        result = librole_validate_filename_from_dir(filename);
+        if (result != LIBROLE_OK)
+            goto exit;
+
+        librole_read_file_from_dir(LIBROLE_CONFIG_DIR, filename, &G);
+    } else {
+        result = librole_reading(LIBROLE_CONFIG, &G);
+        if (result != LIBROLE_OK)
+            goto exit;
+    }
+
+    if (settings.verbose_mode || settings.system_role || settings.roled_filename) {
+        int empty_flag = 0;
+
+        if (settings.verbose_mode && settings.system_role) {
+            printf("# Settings read from system role '%s':\n", settings.system_role);
+        } else if (settings.verbose_mode && settings.roled_filename) {
+            printf("# Settings read from /etc/role.d/%s:\n", settings.roled_filename);
+        } else if (settings.verbose_mode) {
+            printf("# Settings read from /etc/role:\n");
+        }
+
+        if (settings.system_role)
+            empty_flag = 1;
+
         fflush(stdout);
-        result = librole_writing("/dev/stdout", &G, settings.numeric_flag);
+        result = librole_writing("/dev/stdout", &G, settings.numeric_flag, empty_flag);
         if (LIBROLE_OK != result) {
             goto exit;
         }
+        if (settings.system_role || settings.roled_filename)
+            goto exit;
     }
 
     /* Don't check return code in order to retain previous utility
@@ -112,12 +171,14 @@ int main(int argc, char **argv) {
         printf("# Resulting settings merged with /etc/role.d entries\n");
         fflush(stdout);
     }
-    result = librole_writing("/dev/stdout", &G, settings.numeric_flag);
+    result = librole_writing("/dev/stdout", &G, settings.numeric_flag, 1);
     if (LIBROLE_OK != result) {
         goto exit;
     }
 
 exit:
+    if (filename != NULL)
+        free(filename);
     librole_print_error(result);
     librole_graph_free(&G);
     return result;

--- a/test/test_main.c
+++ b/test/test_main.c
@@ -82,11 +82,11 @@ static void test_main(void **state) {
 
     assert_int_equal(librole_graph_init(&G), LIBROLE_OK);
     assert_int_equal(librole_reading("test/role.source", &G), LIBROLE_OK);
-    assert_int_equal(librole_writing("/dev/stdout", &G, 0), LIBROLE_OK);
-    assert_int_equal(librole_writing("/dev/stdout", &G, 1), LIBROLE_OK);
-    assert_int_equal(librole_writing("test/role.test.new", &G, 0), LIBROLE_OK);
-    assert_int_equal(librole_writing("test/role.test.add", &G, 0), LIBROLE_OK);
-    assert_int_equal(librole_writing("test/role.test.del", &G, 0), LIBROLE_OK);
+    assert_int_equal(librole_writing("/dev/stdout", &G, 0, 0), LIBROLE_OK);
+    assert_int_equal(librole_writing("/dev/stdout", &G, 1, 0), LIBROLE_OK);
+    assert_int_equal(librole_writing("test/role.test.new", &G, 0, 0), LIBROLE_OK);
+    assert_int_equal(librole_writing("test/role.test.add", &G, 0, 0), LIBROLE_OK);
+    assert_int_equal(librole_writing("test/role.test.del", &G, 0, 0), LIBROLE_OK);
 
     librole_graph_free(&G);
 }


### PR DESCRIPTION
Add support to rolelst, roleadd and roledel utilities functionality to manage system roles.
System role is a role place in /etc/role.d directory and named same as it role.
System roles also not deleted from dot role files when last privileged removed from this role.
```
$ ./rolelst -S users
users:cdwriter,cdrom,audio,video,proc,radio,camera,floppy,xgrp,scanner,uucp,vboxusers,fuse
$ cat /etc/role.d/users.role 
users: cdwriter, cdrom, audio, video, proc, radio, camera, floppy, xgrp, scanner, uucp, vboxusers, fuse

$ ./rolelst -h
Usage: rolelst [-hnv]
        -h [ --help   ]         produce help message
        -n [ --numeric]         print gid instead of group names
        -v [ --version]         print roledel version being used
        -V [ --verbose]         print extra information about role sources
        -f [ --file=file.role ] show role in additional file /etc/role.d/file.role
        -S [ --system=ROLE ]    show system ROLE in additional file /etc/role.d/ROLE.role

$ ./roleadd -h
Usage: roleadd [-hsmv] ROLE [*PRIVS]
        -h [ --help ]           produce help message
        -s [ --set ]            set role with that privileges only (override)
        -m [ --skip-missing-groups ]    skip missed privileges
        -v [ --version]         print roleadd version being used
        -f [ --file=file.role ] change role in additional file /etc/role.d/file.role
        -S [ --system ] change system ROLE in additional file /etc/role.d/ROLE.role

$ ./roledel -h
Usage: roledel [-hrmv] ROLE [*PRIVS]
        -h [ --help ]           produce help message
        -r [ --remove ]         remove all privileges from role
        -m [ --skip-missing-groups ]    skip missed privileges
        -v [ --version]         print roledel version being used
        -f [ --file=file.role ] change role in additional file /etc/role.d/file.role
        -S [ --system ] change system ROLE in additional file /etc/role.d/ROLE.role
```